### PR TITLE
feat: Comprehensive tests for subscription lifecycle

### DIFF
--- a/tests/Feature/SubscriptionCallbackTest.php
+++ b/tests/Feature/SubscriptionCallbackTest.php
@@ -1,0 +1,148 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use App\Models\SubscriptionPlan;
+use App\Models\UserSubscription;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Carbon;
+use Tests\TestCase;
+
+class SubscriptionCallbackTest extends TestCase
+{
+    use RefreshDatabase;
+
+    // --- Tests for subscriptions.success ---
+
+    public function test_success_callback_redirects_unauthenticated_user(): void
+    {
+        $response = $this->get(route('subscriptions.success'));
+        $response->assertRedirect(route('login'));
+    }
+
+    public function test_success_callback_missing_subscription_id_redirects_with_error(): void
+    {
+        $user = User::factory()->create();
+        $response = $this->actingAs($user)->get(route('subscriptions.success')); // No subscription_id query param
+
+        $response->assertRedirect(route('subscriptions.index'));
+        $response->assertSessionHas('error', 'Subscription confirmation from PayPal is missing an ID. Please check your dashboard or contact support.');
+    }
+
+    public function test_success_callback_updates_status_for_pending_approval_subscription(): void
+    {
+        $user = User::factory()->create();
+        $plan = SubscriptionPlan::factory()->create();
+        $paypalSubId = 'I-TESTSUCCESS123';
+        $subscription = UserSubscription::factory()->for($user)->for($plan)->create([
+            'paypal_subscription_id' => $paypalSubId,
+            'status' => 'pending_approval',
+        ]);
+
+        $response = $this->actingAs($user)
+                         ->get(route('subscriptions.success', ['subscription_id' => $paypalSubId, 'token' => 'test_token']));
+
+        $response->assertRedirect(route('dashboard'));
+        $response->assertSessionHas('success', 'Thank you! Your subscription with PayPal is approved and will be activated shortly.');
+
+        $subscription->refresh();
+        $this->assertEquals('pending_webhook_confirmation', $subscription->status);
+    }
+
+    public function test_success_callback_does_not_change_status_if_not_pending_approval(): void
+    {
+        $user = User::factory()->create();
+        $plan = SubscriptionPlan::factory()->create();
+        $paypalSubId = 'I-TESTALREADYACTIVE';
+        $initialStatus = 'active'; // or 'pending_webhook_confirmation'
+        $subscription = UserSubscription::factory()->for($user)->for($plan)->create([
+            'paypal_subscription_id' => $paypalSubId,
+            'status' => $initialStatus,
+        ]);
+
+        $response = $this->actingAs($user)
+                         ->get(route('subscriptions.success', ['subscription_id' => $paypalSubId, 'token' => 'test_token']));
+
+        $response->assertRedirect(route('dashboard'));
+        $response->assertSessionHas('success'); // Still shows general success
+
+        $subscription->refresh();
+        $this->assertEquals($initialStatus, $subscription->status); // Status should remain unchanged
+    }
+
+    public function test_success_callback_no_matching_local_subscription_redirects_with_warning(): void
+    {
+        $user = User::factory()->create();
+        $paypalSubId = 'I-TESTNOMATCH';
+
+        $response = $this->actingAs($user)
+                         ->get(route('subscriptions.success', ['subscription_id' => $paypalSubId, 'token' => 'test_token']));
+
+        $response->assertRedirect(route('dashboard'));
+        $response->assertSessionHas('warning', 'Your PayPal transaction was successful, but we encountered an issue linking it to your account. Please contact support.');
+    }
+
+    // --- Tests for subscriptions.cancel ---
+
+    public function test_cancel_callback_redirects_unauthenticated_user(): void
+    {
+        $response = $this->get(route('subscriptions.cancel'));
+        $response->assertRedirect(route('login'));
+    }
+
+    public function test_cancel_callback_updates_status_for_pending_approval_subscription(): void
+    {
+        $user = User::factory()->create();
+        $plan = SubscriptionPlan::factory()->create();
+        $subscription = UserSubscription::factory()->for($user)->for($plan)->create([
+            'status' => 'pending_approval',
+            'ends_at' => null, // ends_at might be null before this point
+        ]);
+
+        Carbon::setTestNow(now()); // Freeze time for ends_at comparison
+
+        $response = $this->actingAs($user)->get(route('subscriptions.cancel'));
+
+        $response->assertRedirect(route('subscriptions.index'));
+        $response->assertSessionHas('info', 'You have cancelled the subscription process.');
+
+        $subscription->refresh();
+        $this->assertEquals('cancelled_by_user_at_paypal', $subscription->status);
+        $this->assertNotNull($subscription->ends_at);
+        $this->assertTrue($subscription->ends_at->isSameSecond(Carbon::getTestNow()), "ends_at {$subscription->ends_at} should be the same second as " . Carbon::getTestNow());
+
+        Carbon::setTestNow(); // Clear frozen time
+    }
+
+    public function test_cancel_callback_does_not_affect_non_pending_approval_subscriptions(): void
+    {
+        $user = User::factory()->create();
+        $plan = SubscriptionPlan::factory()->create();
+        $activeSubscription = UserSubscription::factory()->for($user)->for($plan)->create([
+            'status' => 'active', // Not 'pending_approval'
+            'ends_at' => now()->addMonth(),
+        ]);
+        $originalEndsAt = $activeSubscription->ends_at;
+
+        $response = $this->actingAs($user)->get(route('subscriptions.cancel'));
+
+        $response->assertRedirect(route('subscriptions.index'));
+        $response->assertSessionHas('info', 'You have cancelled the subscription process.');
+
+        $activeSubscription->refresh();
+        $this->assertEquals('active', $activeSubscription->status);
+        $this->assertTrue($originalEndsAt->equalTo($activeSubscription->ends_at)); // ends_at should be unchanged
+    }
+
+    public function test_cancel_callback_no_pending_approval_subscription_still_redirects_with_info(): void
+    {
+        $user = User::factory()->create();
+        // No subscriptions created for this user, or none are 'pending_approval'
+
+        $response = $this->actingAs($user)->get(route('subscriptions.cancel'));
+
+        $response->assertRedirect(route('subscriptions.index'));
+        $response->assertSessionHas('info', 'You have cancelled the subscription process.');
+    }
+}

--- a/tests/Unit/UserSubscriptionScopeTest.php
+++ b/tests/Unit/UserSubscriptionScopeTest.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Models\User;
+use App\Models\SubscriptionPlan;
+use App\Models\UserSubscription;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Carbon;
+use Tests\TestCase; // Laravel's base TestCase for unit/feature tests
+
+class UserSubscriptionScopeTest extends TestCase // Ensure it extends Laravel's TestCase
+{
+    use RefreshDatabase;
+
+    public function test_active_scope_returns_only_active_subscriptions_with_future_ends_at(): void
+    {
+        $user = User::factory()->create();
+        $plan = SubscriptionPlan::factory()->create();
+
+        // 1. Active subscription, ends_at in future
+        $activeSubFutureEnd = UserSubscription::factory()->for($user)->for($plan)->create([
+            'status' => 'active',
+            'ends_at' => Carbon::now()->addMonth(),
+        ]);
+
+        // 2. Active subscription, ends_at is null (ongoing)
+        $activeSubNullEnd = UserSubscription::factory()->for($user)->for($plan)->create([
+            'status' => 'active',
+            'ends_at' => null,
+        ]);
+
+        // 3. Active subscription, but ends_at in past (should NOT be returned by scope)
+        UserSubscription::factory()->for($user)->for($plan)->create([
+            'status' => 'active',
+            'ends_at' => Carbon::now()->subDay(),
+        ]);
+
+        // 4. Cancelled subscription, ends_at in future (should NOT be returned)
+        UserSubscription::factory()->for($user)->for($plan)->create([
+            'status' => 'cancelled',
+            'ends_at' => Carbon::now()->addMonth(),
+        ]);
+
+        // 5. Expired subscription (should NOT be returned)
+        UserSubscription::factory()->for($user)->for($plan)->create([
+            'status' => 'expired',
+            'ends_at' => Carbon::now()->subMonth(),
+        ]);
+
+        // 6. Pending subscription (should NOT be returned)
+        UserSubscription::factory()->for($user)->for($plan)->create([
+            'status' => 'pending_approval',
+            'ends_at' => Carbon::now()->addMonth(),
+        ]);
+
+
+        $activeSubscriptionsFromScope = UserSubscription::active()->get();
+
+        $this->assertCount(2, $activeSubscriptionsFromScope, 'Should find 2 active subscriptions.');
+        $this->assertTrue(
+            $activeSubscriptionsFromScope->contains($activeSubFutureEnd),
+            'Active subscription with future ends_at not found.'
+        );
+        $this->assertTrue(
+            $activeSubscriptionsFromScope->contains($activeSubNullEnd),
+            'Active subscription with null ends_at not found.'
+        );
+    }
+}


### PR DESCRIPTION
I've implemented Phase 1 of subscription testing, focusing on the core lifecycle: viewing plans, initiating subscriptions (with workarounds for SDK issues), handling PayPal webhooks, processing callbacks, and user status viewing.

Key changes:

1.  **Subscription Plan Viewing (`SubscriptionController@index`):**
    - I added feature tests for plan visibility and authentication.
    - I fixed a Blade layout issue in `subscriptions/index.blade.php`.

2.  **Subscription Initiation (`SubscriptionController@subscribe`):**
    - **SDK Workaround:** The `paypal/paypal-server-sdk:1.1.0` lacks the expected `SubscriptionsCreateRequest`. The actual PayPal API call in `subscribe()` is now stubbed: it logs this issue, simulates a successful initiation (generates fake PayPal ID & URL), creates a local `UserSubscription` as 'pending_approval', and redirects.
    - I created tests for `subscribe()` to verify this stubbed behavior and other internal logic (user checks, plan validity, DB record creation).

3.  **PayPal Webhook Handling (`PayPalWebhookController@handle`):**
    - I created JSON fixtures for various webhook events.
    - I added extensive feature tests for:
        - Invalid payloads, unhandled events.
        - `BILLING.SUBSCRIPTION.ACTIVATED` - `BILLING.SUBSCRIPTION.CANCELLED` - `BILLING.SUBSCRIPTION.EXPIRED` - `BILLING.SUBSCRIPTION.SUSPENDED` - `PAYMENT.SALE.COMPLETED` - `PAYMENT.SALE.DENIED`
    - These tests confirm correct `UserSubscription` updates and logging.
    - I enhanced controller error logging and test log assertions (`Log::spy()`).

4.  **User Subscription Status Viewing (Dashboard):**
    - I enhanced `DashboardTest.php` to assert correct display of various subscription states (active, none, and how cancelled/expired are handled by the current `active()` scope logic).

5.  **Subscription Callbacks (`SubscriptionController@success`, `SubscriptionController@cancel`):**
    - I added feature tests to ensure these routes correctly handle parameters, update local subscription status if appropriate, and manage session messages.

6.  **Unit Test for `UserSubscription::scopeActive()`:**
    - I added a specific unit test to validate the active scope's logic.

This significantly improves test coverage for subscription management. The primary known issue is the non-functional direct PayPal subscription creation in `SubscriptionController@subscribe` due to the limitations of the currently used PayPal SDK version. This part of the code is now clearly marked and stubbed.