### PR TITLE
feat: Implement admin dashboard and login redirect logic

### DIFF
--- a/app/Http/Controllers/Admin/DashboardController.php
+++ b/app/Http/Controllers/Admin/DashboardController.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use App\Http\Controllers\Controller; // Make sure it extends the base Controller
+use Illuminate\Http\Request;
+
+class DashboardController extends Controller
+{
+    public function index()
+    {
+        return view('admin.dashboard');
+    }
+}

--- a/app/Http/Controllers/Auth/AuthenticatedSessionController.php
+++ b/app/Http/Controllers/Auth/AuthenticatedSessionController.php
@@ -28,6 +28,9 @@ class AuthenticatedSessionController extends Controller
 
         $request->session()->regenerate();
 
+        if (Auth::user()->is_admin) {
+            return redirect()->intended(route('admin.dashboard'));
+        }
         return redirect()->intended(route('dashboard', absolute: false));
     }
 

--- a/resources/views/admin/dashboard.blade.php
+++ b/resources/views/admin/dashboard.blade.php
@@ -1,0 +1,40 @@
+<x-app-layout>
+    <x-slot name="header">
+        <h2 class="font-semibold text-xl text-gray-800 dark:text-gray-200 leading-tight">
+            {{ __('Admin Dashboard') }}
+        </h2>
+    </x-slot>
+
+    <div class="py-12">
+        <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
+            <div class="bg-white dark:bg-gray-800 overflow-hidden shadow-sm sm:rounded-lg">
+                <div class="p-6 text-gray-900 dark:text-gray-100">
+                    <h3 class="text-lg font-medium mb-4">{{ __('Welcome to the Admin Dashboard!') }}</h3>
+                    <p class="mb-6">{{ __("From here you can manage various aspects of the application.") }}</p>
+
+                    <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+                        <!-- Manage Subscription Plans -->
+                        <a href="{{ route('admin.subscription-plans.index') }}" class="block p-6 bg-white dark:bg-gray-700 border border-gray-200 dark:border-gray-600 rounded-lg shadow hover:bg-gray-100 dark:hover:bg-gray-600">
+                            <h5 class="mb-2 text-2xl font-bold tracking-tight text-gray-900 dark:text-white">{{ __('Subscription Plans') }}</h5>
+                            <p class="font-normal text-gray-700 dark:text-gray-400">{{ __('Manage subscription plans available to users.') }}</p>
+                        </a>
+
+                        <!-- Manage Static Pages -->
+                        <a href="{{ route('admin.static-pages.index') }}" class="block p-6 bg-white dark:bg-gray-700 border border-gray-200 dark:border-gray-600 rounded-lg shadow hover:bg-gray-100 dark:hover:bg-gray-600">
+                            <h5 class="mb-2 text-2xl font-bold tracking-tight text-gray-900 dark:text-white">{{ __('Static Pages') }}</h5>
+                            <p class="font-normal text-gray-700 dark:text-gray-400">{{ __('Manage static content pages like About Us, Terms, etc.') }}</p>
+                        </a>
+
+                        <!-- Tax Configuration -->
+                        <a href="{{ route('admin.tax-configuration.index') }}" class="block p-6 bg-white dark:bg-gray-700 border border-gray-200 dark:border-gray-600 rounded-lg shadow hover:bg-gray-100 dark:hover:bg-gray-600">
+                            <h5 class="mb-2 text-2xl font-bold tracking-tight text-gray-900 dark:text-white">{{ __('Tax Configuration') }}</h5>
+                            <p class="font-normal text-gray-700 dark:text-gray-400">{{ __('Configure tax rates and settings.') }}</p>
+                        </a>
+
+                        {{-- Add more links here as other admin features are developed --}}
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</x-app-layout>

--- a/routes/web.php
+++ b/routes/web.php
@@ -18,18 +18,20 @@ Route::middleware('auth')->group(function () {
 
 require __DIR__.'/auth.php';
 
-// Admin Routes for Subscription Plans
+// Admin Routes
 use App\Http\Controllers\Admin\SubscriptionPlanController;
+use App\Http\Controllers\Admin\DashboardController as AdminDashboardController; // Added for Admin Dashboard
+use App\Http\Controllers\Admin\StaticPageController;
+use App\Http\Controllers\Admin\TaxConfigurationController;
 
 Route::middleware(['auth', 'admin'])->prefix('admin')->name('admin.')->group(function () {
-    Route::resource('subscription-plans', SubscriptionPlanController::class);
+    Route::get('/dashboard', [AdminDashboardController::class, 'index'])->name('dashboard'); // New dashboard route
+    Route::resource('subscription-plans', SubscriptionPlanController::class); // Consolidated
+    Route::resource('static-pages', StaticPageController::class)->parameters(['static-pages' => 'staticPage:slug']); // Consolidated
+    Route::get('tax-configuration', [TaxConfigurationController::class, 'index'])->name('tax-configuration.index'); // Consolidated
+    Route::post('tax-configuration/clear-cache', [TaxConfigurationController::class, 'clearConfigCache'])->name('tax-configuration.clear-cache'); // Consolidated
 });
-
-// ADMIN SUBSCRIPTION PLAN ROUTES START
-Route::middleware(['auth', 'admin'])->prefix('admin')->name('admin.')->group(function () {
-    Route::resource('subscription-plans', SubscriptionPlanController::class);
-});
-// ADMIN SUBSCRIPTION PLAN ROUTES END
+// Removed duplicated and misplaced admin route blocks
 
 // USER SUBSCRIPTION ROUTES START
 use App\Http\Controllers\SubscriptionController;
@@ -46,19 +48,6 @@ Route::middleware(['auth'])->prefix('subscriptions')->name('subscriptions.')->gr
 use App\Http\Controllers\PayPalWebhookController;
 Route::post('/paypal/webhook', [PayPalWebhookController::class, 'handle'])->name('paypal.webhook');
 // PAYPAL WEBHOOK ROUTE END
-
-// ADMIN STATIC PAGES ROUTES START
-use App\Http\Controllers\Admin\StaticPageController; // Ensure this is not duplicated if already present
-use App\Http\Controllers\Admin\TaxConfigurationController;
-
-Route::middleware(['auth', 'admin'])->prefix('admin')->name('admin.')->group(function () {
-    Route::resource('static-pages', StaticPageController::class)->parameters(['static-pages' => 'staticPage:slug']);
-});
-// ADMIN STATIC PAGES ROUTES END
-// ADMIN TAX CONFIGURATION ROUTE START
-    Route::get('tax-configuration', [TaxConfigurationController::class, 'index'])->name('tax-configuration.index');
-    Route::post('tax-configuration/clear-cache', [TaxConfigurationController::class, 'clearConfigCache'])->name('tax-configuration.clear-cache');
-// ADMIN TAX CONFIGURATION ROUTE END
 
 // FRONTEND STATIC PAGE ROUTE START
 use App\Http\Controllers\PageController; // Ensure this is not duplicated if already present globally or in another block


### PR DESCRIPTION
This commit introduces a dedicated admin dashboard and updates the login process to redirect admin users to this dashboard, while regular users are directed to their standard dashboard.

Key changes:

1.  **Admin Dashboard Creation:**
    - Added `app/Http/Controllers/Admin/DashboardController.php` with an `index` method.
    - Created `resources/views/admin/dashboard.blade.php` view, which extends the main app layout and includes links to existing admin functions (Subscription Plans, Static Pages, Tax Configuration).
    - Defined a new route `GET /admin/dashboard` (named `admin.dashboard`) protected by `auth` and `admin` middleware.
    - Consolidated existing admin routes into a single route group in `routes/web.php` for better organization.

2.  **Modified Login Redirect Logic:**
    - Updated the `store` method in `app/Http/Controllers/Auth/AuthenticatedSessionController.php`.
    - After successful login, the system now checks if `Auth::user()->is_admin` is true.
        - If admin, redirects to `route('admin.dashboard')`.
        - Otherwise, redirects to `route('dashboard')`.

3.  **Feature Tests for Redirects & Admin Dashboard Access:**
    - Created `tests/Feature/Auth/AdminLoginRedirectTest.php`.
    - Tests verifying that admin users are redirected to the admin dashboard and regular users to the user dashboard upon login are **PASSING**.
    - **Known Issue:** Tests designed to verify access controls for the `admin.dashboard` route itself (e.g., accessible by admin, 403 for regular user, redirect for guest) are currently **FAILING**. This is due to a persistent `BindingResolutionException: Target class [admin] does not exist` when the test environment's HTTP kernel tries to resolve the 'admin' middleware alias. The alias is correctly defined in `app/Http/Kernel.php` and `route:list` resolves it, but the issue persists in the test HTTP request cycle. I troubleshooted this extensively (cache clearing, kernel property names, provider checks) but it remains unresolved. The `is_admin` boolean cast in the User model was also corrected during this process.

This feature enhances the user experience for administrators by providing a dedicated entry point to system management functions. The core redirect logic is functional and tested.